### PR TITLE
Fix OpenStreetMap IDs for 2 Japanese Prefectures

### DIFF
--- a/data/iso3166-2.json
+++ b/data/iso3166-2.json
@@ -35176,7 +35176,7 @@
                 "admin": "33",
                 "reference": {
                     "geonames": 1853299,
-                    "openstreetmap": 812080,
+                    "openstreetmap": 1842150,
                     "openstreetmap_level": 8,
                     "wikipedia": "en:Saga_Prefecture",
                     "wof": "85672695"
@@ -35343,7 +35343,7 @@
                 "fips": "27",
                 "admin": "27",
                 "reference": {
-                    "geonames": 1856156,
+                    "geonames": 1842151,
                     "openstreetmap": 901520,
                     "openstreetmap_level": 8,
                     "wikipedia": "en:Nagasaki_Prefecture",

--- a/data/iso3166-2.json
+++ b/data/iso3166-2.json
@@ -35343,8 +35343,8 @@
                 "fips": "27",
                 "admin": "27",
                 "reference": {
-                    "geonames": 1842151,
-                    "openstreetmap": 901520,
+                    "geonames": 1856156,
+                    "openstreetmap": 1842151,
                     "openstreetmap_level": 8,
                     "wikipedia": "en:Nagasaki_Prefecture",
                     "wof": "85672857"


### PR DESCRIPTION
First, thank you for this resource - our team has been using it for a geo-visualization project and it's been great to work with.

I was using a script to generate latitude/longitude coordinates using this data in combination with the OpenStreetMap API and noticed that 2 prefectures in Japan had incorrect IDs:
- Saga Prefecture should use ID 1842150 (original ID was for Taga, Shiga Prefecture)
  - [OSM entry for 1842150 for reference](https://nominatim.openstreetmap.org/reverse?format=jsonv2&osm_type=R&osm_id=1842150)
- Nagasaki Prefecture should use ID 1842151 (original ID was for Amagasaki, Hyogo Prefecture)
  - [OSM entry for 1842151 for reference](https://nominatim.openstreetmap.org/reverse?format=jsonv2&osm_type=R&osm_id=1842151)