### PR TITLE
fix subdivision name for US-DC

### DIFF
--- a/data/iso3166-2.json
+++ b/data/iso3166-2.json
@@ -86213,16 +86213,16 @@
                 }
             },
             {
-                "name": "Washington, D.C.",
+                "name": "District of Columbia",
                 "names": {
-                    "geonames": "Washington, D.C.",
-                    "ru": "Вашингтон",
-                    "en": "Washington",
+                    "geonames": "District of Columbia",
+                    "ru": "Округ Колумбия",
+                    "en": "District of Columbia",
                     "ar": "واشنطن العاصمة",
-                    "de": "Washington",
-                    "es": "Washington D. C.",
-                    "fr": "Washington",
-                    "it": "Washington",
+                    "de": "District of Columbia",
+                    "es": "Distrito de Columbia",
+                    "fr": "District de Columbia",
+                    "it": "Distretto della Columbia",
                     "zh": "华盛顿哥伦比亚特区"
                 },
                 "iso": "DC",


### PR DESCRIPTION
Washington is the city inside District of Columbia (DC) which is a District created by the US Congress.

See: 
- https://en.wikipedia.org/wiki/ISO_3166-2:US#Current_codes
- https://ru.wikipedia.org/wiki/ISO_3166-2:US#%D0%93%D0%B5%D0%BE%D0%BA%D0%BE%D0%B4%D1%8B_%D0%A1%D0%A8%D0%90