### PR TITLE
Remove extra GF name missing language key

### DIFF
--- a/data/iso3166-2.json
+++ b/data/iso3166-2.json
@@ -24687,7 +24687,6 @@
         "names": {
             "geonames": "French Guiana",
             "en": "French Guiana",
-            "": "French Guiana",
             "ar": "غويانا الفرنسية",
             "de": "Französisch-Guayana",
             "es": "Guayana Francesa",


### PR DESCRIPTION
Empty keys cause problems with some JSON parsers (PowerShell's ConvertFrom-Json cmdlet, e.g.). This looks like it was probably a copy and paste error anyway, since it is the only instance of a country name that isn't providing a language.