### PR TITLE
Fix ISO codes for Polish regions

### DIFF
--- a/data/iso3166-2.json
+++ b/data/iso3166-2.json
@@ -62265,7 +62265,7 @@
                     "geonames": 858790,
                     "openstreetmap": 130914,
                     "openstreetmap_level": 4,
-                    "wikipedia": "en:Skierniewice_Voivodeship",
+                    "wikipedia": "en:Świętokrzyskie_Voivodeship",
                     "wof": null
                 }
             },


### PR DESCRIPTION
Performed a migration of Polish region codes as hinted in this issue: https://github.com/esosedi/3166/issues/38. Verified data with https://en.wikipedia.org/wiki/ISO_3166-2:PL and https://www.iso.org/obp/ui/#iso:code:3166:PL.

I only changed the data/iso3166-2.json file, are any other changes required before this can be merged and released?