### PR TITLE
Fix German New York name 

### DIFF
--- a/data/iso3166-2.json
+++ b/data/iso3166-2.json
@@ -87724,7 +87724,7 @@
                     "ru": "Нью-Йорк",
                     "en": "New York",
                     "ar": "نيويورك",
-                    "de": "New York City",
+                    "de": "New York",
                     "es": "Nueva York",
                     "fr": "New York",
                     "it": "New York",


### PR DESCRIPTION
The state of New York was named "New York City" for the German locale. This is obviously incorrect, so this PR fixes this.

Resources:
- https://de.wikipedia.org/wiki/ISO_3166-2:US#Bundesstaaten
